### PR TITLE
change whitelist_externals to allowlist_externals to fix broken tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ skip_install = true
 setenv =
   LC_ALL=en_US.UTF-8
 
-whitelist_externals =
+allowlist_externals =
   make
   poetry
 


### PR DESCRIPTION
I noticed that the CI was failing because `tox` now expects a `allowlist_externals` key instead of a `whitelist_externals` key.