### PR TITLE
Fix CI for windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ['3.9', '3.10', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         exclude:
           - os: windows
             python-version: pypy3
@@ -36,6 +36,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
+      - if: ${{ matrix.os == 'windows' }}
+        run: |
+          poetry config installer.max-workers 1
       - run: tox
       - if: ${{ matrix.os == 'ubuntu' && matrix.python-version == '3.8' }}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ flask = ">2"
 [tool.poetry.dev-dependencies]
 abilian-devtools = ">0.5"
 devtools = ">0.12"
-honcho = ">1.1"
-pyanalyze = ">0.11"
+honcho = ">=1.1"
+pyanalyze = ">=0.11"
 pytest = ">7"
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ setenv =
   LC_ALL=en_US.UTF-8
 
 allowlist_externals =
-  make
   poetry
 
 commands_pre =
@@ -23,6 +22,11 @@ commands =
 [testenv:lint]
 basepython =
   python3
+
+allowlist_externals =
+  poetry
+  make
+  safety
 
 commands =
   make lint


### PR DESCRIPTION
There appears to be a race condition with `poetry` (see https://github.com/python-poetry/poetry/issues/7611 as well as https://github.com/python-poetry/poetry/pull/8517 which fixes the issue but hasn't been merged yet), and it breaks the CI build for Windows.

Moreover, the dev dependencies were incorrectly specified using non-inclusive greater-than with the latest package version for some of the packages.

Note: Windows CI still fails because one of the tests is actually failing on Windows.