### PR TITLE
Fixup! Directory separator on windows

### DIFF
--- a/src/flask_vite/tags.py
+++ b/src/flask_vite/tags.py
@@ -20,8 +20,8 @@ def make_tag(*, static: bool = False):
 
 
 def make_static_tag():
-    js_file = glob.glob("vite/dist/assets/*.js")[0].split("/")[-1]
-    css_file = glob.glob("vite/dist/assets/*.css")[0].split("/")[-1]
+    js_file = glob.glob("vite/dist/assets/*.js")[0].replace('\\','/').split("/")[-1]
+    css_file = glob.glob("vite/dist/assets/*.css")[0].replace('\\','/').split("/")[-1]
 
     js_file_url = url_for("vite.static", filename=js_file)
     css_file_url = url_for("vite.static", filename=css_file)


### PR DESCRIPTION
On the Windows platform, file paths contain a different separator. Thus, as a result, the final file is incorrectly determined