### PR TITLE
fix: Assets url generation endpoint

### DIFF
--- a/src/flask_vite/tags.py
+++ b/src/flask_vite/tags.py
@@ -25,8 +25,8 @@ def make_static_tag():
     js_file = Path(glob.glob(f"{vite_folder_path}/dist/assets/*.js")[0]).name
     css_file = Path(glob.glob(f"{vite_folder_path}/dist/assets/*.css")[0]).name
 
-    js_file_url = url_for(f"{vite_folder_path}.static", filename=js_file)
-    css_file_url = url_for(f"{vite_folder_path}.static", filename=css_file)
+    js_file_url = url_for("vite.static", filename=js_file)
+    css_file_url = url_for("vite.static", filename=css_file)
 
     return dedent(
         f"""


### PR DESCRIPTION
Hello,

I noticed that the value of the `endpoint` argument passed to `url_for` has been wrongly modified, the endpoint name is still `"vite.static`". The issue obviously only occurs when the vite folder path chosen is different from `vite`. 