### PR TITLE
Fix vite.static endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - if: ${{ matrix.os == 'ubuntu' }}
         run: sudo apt-get install strace
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -U pip setuptools wheel tox tox-gh-actions poetry
       - id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.3] - 2025-02-22
+
+### <!-- 1 -->🐛 Bug Fixes
+- Fixed non-debug static asset URL generation when using VITE_FOLDER_PATH. See https://github.com/abilian/flask-vite/pull/15.
+
+## [0.5.2] - 2024-10-07
+
+### 💣 Breaking Change
+- Renamed NPM_BIN_PATH configuration variable to VITE_NPM_BIN_PATH
+
+### <!-- 0 -->🚀 Features
+- Added VITE_FOLDER_PATH configuration variable; default value of `vite`. See https://github.com/abilian/flask-vite/pull/12.
+
 ## [0.5.1] - 2024-07-16
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask-vite"
-version = "0.5.2"
+version = "0.5.3"
 homepage = "https://github.com/abilian/flask-vite"
 description = "Flask+Vite integration."
 authors = ["Abilian SAS <contact@abilian.com>"]

--- a/src/flask_vite/tags.py
+++ b/src/flask_vite/tags.py
@@ -25,8 +25,8 @@ def make_static_tag():
     js_file = Path(glob.glob(f"{vite_folder_path}/dist/assets/*.js")[0]).name
     css_file = Path(glob.glob(f"{vite_folder_path}/dist/assets/*.css")[0]).name
 
-    js_file_url = url_for(f"{vite_folder_path}.static", filename=js_file)
-    css_file_url = url_for(f"{vite_folder_path}.static", filename=css_file)
+    js_file_url = url_for("vite.static", filename=js_file)
+    css_file_url = url_for("vite.static", filename=css_file)
 
     return dedent(
         f"""

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,10 @@ allowlist_externals =
   poetry
 
 commands_pre =
-  pip install -U pip setuptools wheel
-  poetry install --remove-untracked -q
+  poetry sync --all-groups
 
 commands =
-  pytest
+  poetry run pytest
 
 
 [testenv:lint]


### PR DESCRIPTION
When the vite static endpoint is setup in vite.init_app, the endpoint name is hardcoded as `vite.static`:

```
app.route(
    "/_vite/<path:filename>", endpoint="vite.static", host=self.vite_routes_host
)(self.vite_static)
```

The `make_static_tag` function, however, injects the `vite_folder_path` variable into the endpoint name:

```
js_file_url = url_for(f"{vite_folder_path}.static", filename=js_file)
css_file_url = url_for(f"{vite_folder_path}.static", filename=css_file)
```

If you override the vite folder path from the default value of `vite`, then these URLs don't resolve. For example a vite folder path of `app/vite` would try to build URLs for `app/vite.static` - which doesn't exist.