### PR TITLE
Remove closing tag from void link element

### DIFF
--- a/src/flask_vite/tags.py
+++ b/src/flask_vite/tags.py
@@ -32,7 +32,7 @@ def make_static_tag():
         f"""
             <!-- FLASK_VITE_HEADER -->
             <script type="module" src="{js_file_url}"></script>
-            <link rel="stylesheet" href="{css_file_url}"></link>
+            <link rel="stylesheet" href="{css_file_url}" />
         """
     ).strip()
 


### PR DESCRIPTION
`link` is a void element in the HTML:
https://developer.mozilla.org/en-US/docs/Glossary/Void_element. It should not have a closing tag.